### PR TITLE
add cheats for add-dependency and add-extension

### DIFF
--- a/contributors/cheatsheet.md
+++ b/contributors/cheatsheet.md
@@ -20,6 +20,23 @@ cd name_of_new_plugin
 yo phovea
 ```
 
+Depend on another plugin or library
+-----------------------------------
+
+```
+cd name_of_new_plugin
+yo phovea:add-dependency
+```
+
+
+Define a new extension point
+----------------------------
+
+```
+cd name_of_new_plugin
+yo phovea:add-extension
+```
+
 Launch a Phovea application
 ----------------------------
 


### PR DESCRIPTION
@sgratzl : Should this documentation be added? I'm also not sure whether it's working correctly:
```
workspace$ yo phovea:add-dependency
? Additional Modules (Press <space> to select, <a> to toggle all, <i> to inverse selection)
```
... but no choices are presented.

For the second one, some suggestion of what an extension point is might be useful. Perhaps point to another section of the docs?
