### PR TITLE
Remove reference to app

### DIFF
--- a/contributors/adding-dependencies.md
+++ b/contributors/adding-dependencies.md
@@ -15,7 +15,7 @@ A client-side dependency can be another Phovea module or a JavaScript library av
 
 ### Phovea modules and additional libraries
 
-1. Open the command line and navigate to the application/plugin directory
+1. Open the command line and navigate to the plugin directory
 2. Run `yo phovea:add-dependency`
 3. Select the *additional (Phovea) modules* that should be included
 4. Confirm your selection with Enter and move the next step


### PR DESCRIPTION
In given context it is enough to know it is a plugin.